### PR TITLE
feat: support filtering servers based on available models

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -16,7 +16,13 @@ type Router struct {
 	strategy     routerStrategy
 }
 
-// NewRouter creates an instance of the Router that routes requests to one or more openai/azureopenai servers
+// NewRouter creates a new Router instance with the given server configurations and strategy type.
+// It returns a pointer to the Router and an error if any.
+// The serverConfigs parameter is a slice of server.ServerConfig that contains the configurations for each server.
+// The strategyType parameter is the type of router strategy to be used.
+// If the serverConfigs slice is empty, it returns an error with the message "empty server config".
+// Otherwise, it creates a new RouterServer for each server configuration and adds them to the servers slice.
+// Finally, it initializes the Router with the servers, serverCount, requestCount, and strategy.
 func NewRouter(serverConfigs []server.ServerConfig, strategyType RouterStrategyType) (*Router, error) {
 	servers := []*server.RouterServer{}
 	if len(serverConfigs) == 0 {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -43,7 +43,12 @@ func NewRouter(serverConfigs []server.ServerConfig, strategyType RouterStrategyT
 // If the operation fails it returns an *azcore.ResponseError type.
 func (r *Router) GetChatCompletions(ctx context.Context, body azopenai.ChatCompletionsOptions, options *azopenai.GetChatCompletionsOptions) (azopenai.GetChatCompletionsResponse, error) {
 	r.requestCount++
-	return r.strategy.GetAvailableServer(r).GetChatCompletions(ctx, body, options)
+	modelName := *body.DeploymentName
+	server := r.strategy.GetAvailableServer(r, modelName)
+	if server == nil {
+		return azopenai.GetChatCompletionsResponse{}, fmt.Errorf("no server available for model %s", modelName)
+	}
+	return server.GetChatCompletions(ctx, body, options)
 }
 
 // GetChatCompletionsStream - Return the chat completions for a given prompt as a sequence of events.
@@ -51,5 +56,10 @@ func (r *Router) GetChatCompletions(ctx context.Context, body azopenai.ChatCompl
 //   - options - GetCompletionsOptions contains the optional parameters for the Client.GetCompletions method.
 func (r *Router) GetChatCompletionsStream(ctx context.Context, body azopenai.ChatCompletionsOptions, options *azopenai.GetChatCompletionsStreamOptions) (azopenai.GetChatCompletionsStreamResponse, error) {
 	r.requestCount++
-	return r.strategy.GetAvailableServer(r).GetChatCompletionsStream(ctx, body, options)
+	modelName := *body.DeploymentName
+	server := r.strategy.GetAvailableServer(r, modelName)
+	if server == nil {
+		return azopenai.GetChatCompletionsStreamResponse{}, fmt.Errorf("no server available for model %s", modelName)
+	}
+	return server.GetChatCompletionsStream(ctx, body, options)
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -28,7 +28,10 @@ func TestNewRouter(t *testing.T) {
 
 func TestGetChatCompletions(t *testing.T) {
 	router := getRouter()
-	router.GetChatCompletions(context.TODO(), azopenai.ChatCompletionsOptions{}, nil)
+	deploymentName := "gpt-3.5-turbo"
+	router.GetChatCompletions(context.TODO(), azopenai.ChatCompletionsOptions{
+		DeploymentName: &deploymentName,
+	}, nil)
 	if router.requestCount != 1 {
 		t.Fatalf("Incorrect requests count %d", router.requestCount)
 	}
@@ -36,7 +39,10 @@ func TestGetChatCompletions(t *testing.T) {
 
 func TestGetChatCompletionsStream(t *testing.T) {
 	router := getRouter()
-	router.GetChatCompletionsStream(context.TODO(), azopenai.ChatCompletionsOptions{}, nil)
+	deploymentName := "gpt-3.5-turbo"
+	router.GetChatCompletions(context.TODO(), azopenai.ChatCompletionsOptions{
+		DeploymentName: &deploymentName,
+	}, nil)
 	if router.requestCount != 1 {
 		t.Fatalf("Incorrect requests count %d", router.requestCount)
 	}
@@ -45,7 +51,10 @@ func TestGetChatCompletionsStream(t *testing.T) {
 func getRouter() *Router {
 	router, _ := NewRouter([]server.ServerConfig{
 		{
-			Type: server.OpenAiServerType,
+			Type:            server.OpenAiServerType,
+			Endpoint:        "https://azure-openai.com",
+			ApiKey:          "azure-openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo", "gpt-4-turbo"},
 		},
 	}, RoundRobinStrategy)
 	return router

--- a/pkg/router/strategy.go
+++ b/pkg/router/strategy.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"log/slog"
+	"slices"
 
 	"github.com/acai-travel/go-openai-router/pkg/server"
 )
@@ -18,7 +19,7 @@ const (
 )
 
 type routerStrategy interface {
-	GetAvailableServer(router *Router) *server.RouterServer
+	GetAvailableServer(router *Router, modelName string) *server.RouterServer
 }
 
 func newRouterStrategy(strategyType RouterStrategyType) routerStrategy {
@@ -37,37 +38,65 @@ func newRouterStrategy(strategyType RouterStrategyType) routerStrategy {
 type simpleRoundRobinRouterStrategy struct{}
 
 // Implement simple round robin
-func (s *simpleRoundRobinRouterStrategy) GetAvailableServer(r *Router) *server.RouterServer {
-	serverIndex := r.requestCount % r.serverCount
+func (s *simpleRoundRobinRouterStrategy) GetAvailableServer(r *Router, modelName string) *server.RouterServer {
+	filteredServers := []*server.RouterServer{}
+	for _, server := range r.servers {
+		if slices.Contains(server.AvailableModels, modelName) {
+			filteredServers = append(filteredServers, server)
+		}
+	}
+	if len(filteredServers) == 0 {
+		return nil
+	}
+	serverIndex := r.requestCount % len(filteredServers)
 	slog.Debug("Simple Round Robin Server", "serverIndex", serverIndex)
-	return r.servers[serverIndex]
+	return filteredServers[serverIndex]
 }
 
 type leastConnectionServerStrategy struct{}
 
 // Implement least busy using active connections
-func (s *leastConnectionServerStrategy) GetAvailableServer(r *Router) *server.RouterServer {
-	var serverIndex = 0
-	for k, server := range r.servers {
-		if server.ActiveConnections <= r.servers[serverIndex].ActiveConnections {
-			serverIndex = k
+func (s *leastConnectionServerStrategy) GetAvailableServer(r *Router, modelName string) *server.RouterServer {
+	filteredServers := make([]*server.RouterServer, 0)
+	for _, server := range r.servers {
+		if slices.Contains(server.AvailableModels, modelName) {
+			filteredServers = append(filteredServers, server)
 		}
 	}
-	slog.Debug("Least Busy Server", "serverIndex", serverIndex)
-	return r.servers[serverIndex]
+
+	if len(filteredServers) == 0 {
+		return nil
+	}
+
+	minConnectionsServer := filteredServers[0]
+	for _, server := range filteredServers {
+		if server.ActiveConnections < minConnectionsServer.ActiveConnections {
+			minConnectionsServer = server
+		}
+	}
+	return minConnectionsServer
 }
 
 type leastLatencyServerStrategy struct{}
 
 // Implement least latency using calculated average latency
-func (s *leastLatencyServerStrategy) GetAvailableServer(r *Router) *server.RouterServer {
-	var serverIndex = 0
-	for k, server := range r.servers {
-		if server.Latency <= r.servers[serverIndex].Latency {
-			serverIndex = k
+func (s *leastLatencyServerStrategy) GetAvailableServer(r *Router, modelName string) *server.RouterServer {
+	filteredServers := make([]*server.RouterServer, 0)
+	for _, server := range r.servers {
+		if slices.Contains(server.AvailableModels, modelName) {
+			filteredServers = append(filteredServers, server)
 		}
 	}
-	slog.Debug("Least Latency Server", "serverIndex", serverIndex)
-	return r.servers[serverIndex]
 
+	if len(filteredServers) == 0 {
+		return nil
+	}
+
+	leastLatencyServer := filteredServers[0]
+	for _, server := range filteredServers {
+		if server.Latency < leastLatencyServer.Latency {
+			leastLatencyServer = server
+		}
+	}
+	return leastLatencyServer
 }

--- a/pkg/router/strategy.go
+++ b/pkg/router/strategy.go
@@ -37,7 +37,9 @@ func newRouterStrategy(strategyType RouterStrategyType) routerStrategy {
 
 type simpleRoundRobinRouterStrategy struct{}
 
-// Implement simple round robin
+// GetAvailableServer returns an available server from the router based on the provided model name.
+// It filters the servers based on the available models and uses a simple round-robin strategy to select a server.
+// If no server is available for the given model, it returns nil.
 func (s *simpleRoundRobinRouterStrategy) GetAvailableServer(r *Router, modelName string) *server.RouterServer {
 	filteredServers := []*server.RouterServer{}
 	for _, server := range r.servers {
@@ -55,7 +57,8 @@ func (s *simpleRoundRobinRouterStrategy) GetAvailableServer(r *Router, modelName
 
 type leastConnectionServerStrategy struct{}
 
-// Implement least busy using active connections
+// GetAvailableServer returns the server with the least active connections that supports the specified model.
+// If no server is available for the model, it returns nil.
 func (s *leastConnectionServerStrategy) GetAvailableServer(r *Router, modelName string) *server.RouterServer {
 	filteredServers := make([]*server.RouterServer, 0)
 	for _, server := range r.servers {
@@ -79,7 +82,8 @@ func (s *leastConnectionServerStrategy) GetAvailableServer(r *Router, modelName 
 
 type leastLatencyServerStrategy struct{}
 
-// Implement least latency using calculated average latency
+// GetAvailableServer returns the server with the least latency that supports the specified model.
+// If no server is available for the model, it returns nil.
 func (s *leastLatencyServerStrategy) GetAvailableServer(r *Router, modelName string) *server.RouterServer {
 	filteredServers := make([]*server.RouterServer, 0)
 	for _, server := range r.servers {

--- a/pkg/router/strategy_test.go
+++ b/pkg/router/strategy_test.go
@@ -28,17 +28,17 @@ func TestRoundRobinStrategy(t *testing.T) {
 	strategy := newRouterStrategy(RoundRobinStrategy)
 	r := getRouterForRoundRobinStrategy()
 	r.requestCount = 0
-	s := strategy.GetAvailableServer(r)
+	s := strategy.GetAvailableServer(r, "gpt-3.5-turbo")
 	if s.Type != server.OpenAiServerType {
 		t.Fatalf("Incorrect server returned by Round Robin - %s", s.Type)
 	}
 	r.requestCount = 1
-	s = strategy.GetAvailableServer(r)
+	s = strategy.GetAvailableServer(r, "gpt-3.5-turbo")
 	if s.Type != server.AzureOpenAiServerType {
 		t.Fatalf("Incorrect server returned by Round Robin - %s", s.Type)
 	}
 	r.requestCount = 2
-	s = strategy.GetAvailableServer(r)
+	s = strategy.GetAvailableServer(r, "gpt-3.5-turbo")
 	if s.Type != server.OpenAiServerType {
 		t.Fatalf("Incorrect server returned by Round Robin - %s", s.Type)
 	}
@@ -47,7 +47,7 @@ func TestRoundRobinStrategy(t *testing.T) {
 func TestLeastActiveConnectionsStrategy(t *testing.T) {
 	r := getRouterForActiveConnectionsStrategy()
 	strategy := newRouterStrategy(LeastConnectionStrategy)
-	s := strategy.GetAvailableServer(r)
+	s := strategy.GetAvailableServer(r, "gpt-3.5-turbo")
 	if s.Type != server.AzureOpenAiServerType {
 		t.Fatalf("Incorrect server returned by Least Active Connection Strategy - %s", s.Type)
 	}
@@ -57,7 +57,7 @@ func TestLeastActiveConnectionsStrategy(t *testing.T) {
 func TestLeastLatencyStrategy(t *testing.T) {
 	r := getRouterForLeastLatencyStrategy()
 	strategy := newRouterStrategy(LeastLatencyStrategy)
-	s := strategy.GetAvailableServer(r)
+	s := strategy.GetAvailableServer(r, "gpt-3.5-turbo")
 	if s.Type != server.OpenAiServerType {
 		t.Fatalf("Incorrect server returned by Least Latency Strategy - %s", s.Type)
 	}
@@ -67,12 +67,18 @@ func TestLeastLatencyStrategy(t *testing.T) {
 func getRouterForActiveConnectionsStrategy() *Router {
 	s1, _ := server.NewRouterServer(
 		server.ServerConfig{
-			Type: server.OpenAiServerType,
+			Type:            server.OpenAiServerType,
+			Endpoint:        "https://api.openai.com",
+			ApiKey:          "openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo"},
 		})
 	s1.ActiveConnections = 10
 	s2, _ := server.NewRouterServer(
 		server.ServerConfig{
-			Type: server.AzureOpenAiServerType,
+			Type:            server.AzureOpenAiServerType,
+			Endpoint:        "https://api.openai.com",
+			ApiKey:          "openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo"},
 		})
 	s2.ActiveConnections = 8
 	return &Router{servers: []*server.RouterServer{s1, s2}}
@@ -81,25 +87,40 @@ func getRouterForActiveConnectionsStrategy() *Router {
 func getRouterForLeastLatencyStrategy() *Router {
 	s1, _ := server.NewRouterServer(
 		server.ServerConfig{
-			Type: server.OpenAiServerType,
+			Type:            server.OpenAiServerType,
+			Endpoint:        "https://api.openai.com",
+			ApiKey:          "openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo"},
 		})
 	s1.Latency = 100
 	s2, _ := server.NewRouterServer(
 		server.ServerConfig{
-			Type: server.AzureOpenAiServerType,
+			Type:            server.AzureOpenAiServerType,
+			Endpoint:        "https://api.openai.com",
+			ApiKey:          "openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo"},
 		})
 	s2.Latency = 6000
 	return &Router{servers: []*server.RouterServer{s1, s2}}
 }
 
 func getRouterForRoundRobinStrategy() *Router {
-	router, _ := NewRouter([]server.ServerConfig{
+	router, err := NewRouter([]server.ServerConfig{
 		{
-			Type: server.OpenAiServerType,
+			Type:            server.OpenAiServerType,
+			Endpoint:        "https://api.openai.com",
+			ApiKey:          "openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo"},
 		},
 		{
-			Type: server.AzureOpenAiServerType,
+			Type:            server.AzureOpenAiServerType,
+			Endpoint:        "https://azure-openai.com",
+			ApiKey:          "azure-openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo", "gpt-4-turbo"},
 		},
 	}, RoundRobinStrategy)
+	if err != nil {
+		panic(err)
+	}
 	return router
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ const (
 	OpenAiServerType      ServerConfigType = "openai"
 )
 
+// ServerConfig represents the configuration for the server.
 type ServerConfig struct {
 	Endpoint        string
 	ApiKey          string
@@ -24,6 +25,7 @@ type ServerConfig struct {
 	AvailableModels []string // AvailableModels is a list of models that are available for the Azure endpoint. The list of models will vary based on the endpoint.
 }
 
+// RouterServer represents the server that the router will use to send requests.
 type RouterServer struct {
 	client            *azopenai.Client
 	ActiveConnections int

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,9 +18,10 @@ const (
 )
 
 type ServerConfig struct {
-	Endpoint string
-	ApiKey   string
-	Type     ServerConfigType
+	Endpoint        string
+	ApiKey          string
+	Type            ServerConfigType
+	AvailableModels []string // AvailableModels is a list of models that are available for the Azure endpoint. The list of models will vary based on the endpoint.
 }
 
 type RouterServer struct {
@@ -30,15 +31,26 @@ type RouterServer struct {
 	Type              ServerConfigType
 	totalRequests     int64
 	totalLatency      int64
+	AvailableModels   []string // AvailableModels is a list of models that are available for the Azure endpoint. The list of models will vary based on the endpoint.
 }
 
 func NewRouterServer(serverConfig ServerConfig) (*RouterServer, error) {
+	if len(serverConfig.ApiKey) == 0 {
+		return nil, fmt.Errorf("empty api key")
+	}
+	if len(serverConfig.Endpoint) == 0 {
+		return nil, fmt.Errorf("empty endpoint")
+	}
+	if len(serverConfig.AvailableModels) == 0 {
+		return nil, fmt.Errorf("empty available models")
+	}
 	server := &RouterServer{
 		ActiveConnections: 0,
 		totalRequests:     0,
 		Latency:           0,
 		totalLatency:      0,
 		Type:              serverConfig.Type,
+		AvailableModels:   serverConfig.AvailableModels,
 	}
 	keyCredential := azcore.NewKeyCredential(serverConfig.ApiKey)
 	switch serverConfig.Type {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -7,7 +7,10 @@ import (
 
 func TestNewServer(t *testing.T) {
 	serverConfig := ServerConfig{
-		Type: OpenAiServerType,
+		Type:            OpenAiServerType,
+		Endpoint:        "https://azure-openai.com",
+		ApiKey:          "azure-openai-key",
+		AvailableModels: []string{"gpt-3.5-turbo", "gpt-4-turbo"},
 	}
 	_, err := NewRouterServer(serverConfig)
 	if err != nil {
@@ -15,7 +18,10 @@ func TestNewServer(t *testing.T) {
 	}
 
 	serverConfig = ServerConfig{
-		Type: "Foo",
+		Type:            "Foo",
+		Endpoint:        "https://azure-openai.com",
+		ApiKey:          "azure-openai-key",
+		AvailableModels: []string{"gpt-3.5-turbo", "gpt-4-turbo"},
 	}
 	_, err = NewRouterServer(serverConfig)
 	if err == nil {
@@ -56,7 +62,10 @@ func TestPostFlight(t *testing.T) {
 func getServer() RouterServer {
 	server, _ := NewRouterServer(
 		ServerConfig{
-			Type: AzureOpenAiServerType,
+			Type:            AzureOpenAiServerType,
+			Endpoint:        "https://azure-openai.com",
+			ApiKey:          "azure-openai-key",
+			AvailableModels: []string{"gpt-3.5-turbo", "gpt-4-turbo"},
 		},
 	)
 	return *server


### PR DESCRIPTION
## Summary

Some Azure regions do not support GPT-4 Vision model. For that reason, we introduced the `AvailableModels` attribute to the server and router configuration so that the load balancing takes into account if endpoint/region has the needed endpoint. Clients of the pkg will need to manually specify the available model names that the endpoint has.